### PR TITLE
fix(demo): correct demo package name

### DIFF
--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cargo"
+name = "demo"
 version = "0.1.0"
 edition = "2024"
 


### PR DESCRIPTION
The demo package's name was erroneously set to "cargo" when moving from a standalone package to a workspace.